### PR TITLE
proper json naming

### DIFF
--- a/x/longy/internal/types/msg_claim_key.go
+++ b/x/longy/internal/types/msg_claim_key.go
@@ -8,8 +8,8 @@ var _ sdk.Msg = MsgClaimKey{}
 
 // MsgClaimKey is used to claim a prior rekey message
 type MsgClaimKey struct {
-	AttendeeAddress sdk.AccAddress
-	Secret          string
+	AttendeeAddress sdk.AccAddress `json:"attendeeAddress"`
+	Secret          string         `json:"secret"`
 }
 
 // NewMsgClaimKey in the constructor for `MsgClaimKey`

--- a/x/longy/internal/types/msg_key.go
+++ b/x/longy/internal/types/msg_key.go
@@ -10,14 +10,14 @@ var _ sdk.Msg = MsgKey{}
 
 // MsgKey implements the `sdk.Msg` interface
 type MsgKey struct {
-	AttendeeAddress      sdk.AccAddress
-	NewAttendeePublicKey tmcrypto.PubKey
+	AttendeeAddress      sdk.AccAddress  `json:"attendeeAddress"`
+	NewAttendeePublicKey tmcrypto.PubKey `json:"newAttendeePublicKey"`
 
 	// expected signer of this message
-	MasterAddress sdk.AccAddress
+	MasterAddress sdk.AccAddress `json:"masterAddress"`
 
 	// Commitmentment that needs to be reclaimed
-	Commitment util.Commitment
+	Commitment util.Commitment `json:"commitment"`
 }
 
 // NewMsgKey is the creator for `RekeyMsg`


### PR DESCRIPTION
consistent naming conventions for msg keys